### PR TITLE
Allow strings together with symbols

### DIFF
--- a/resources/file.rb
+++ b/resources/file.rb
@@ -9,7 +9,7 @@ attribute :locations, :kind_of => [Hash, NilClass], :default => {} # Locations t
 attribute :name, :name_attribute => true, :kind_of => String
 attribute :options, :kind_of => [Hash, NilClass], :default => {} # Key value pairs of options to include in the Server body.
 attribute :upstream, :kind_of => [Hash, NilClass], :default => {} # Key value pair of upstream configuration to include outside Server body.
-attribute :reload, :kind_of => [Symbol], :equal_to => [:delayed, :immediately], :default => :delayed # How soon should we restart nginx.
+attribute :reload, :equal_to => [:delayed, :immediately], :default => :delayed # How soon should we restart nginx.
 attribute :root, :kind_of => [String, NilClass], :default => nil # Server root
 attribute :server_name, :kind_of => [String, Array, NilClass], :default => nil # Server name if different then the name attribute.
 attribute :conf_name, :kind_of => [String, NilClass], :default => nil # Configuration name.
@@ -17,7 +17,7 @@ attribute :socket, :kind_of => [String, NilClass], :default => nil # Path to soc
 attribute :template, :kind_of => [String, NilClass], :default => nil # Template to use.
 attribute :auto_enable_site, :kind_of => [TrueClass, FalseClass] , :default => true # Define if you want to link your newly created site conf from sites-availables to sites-enabled
 attribute :ssl, :kind_of => [Hash, NilClass], :default => nil #Allow the creation of ssl cert files.
-attribute :precedence, :kind_of => Symbol, :default => :default # Level of attribute precedence to use
+attribute :precedence, :default => :default # Level of attribute precedence to use
 attribute :site_type, :equal_to => [:dynamic, :static], :default => :dynamic 
 
 def initialize(*args)

--- a/resources/file.rb
+++ b/resources/file.rb
@@ -9,7 +9,7 @@ attribute :locations, :kind_of => [Hash, NilClass], :default => {} # Locations t
 attribute :name, :name_attribute => true, :kind_of => String
 attribute :options, :kind_of => [Hash, NilClass], :default => {} # Key value pairs of options to include in the Server body.
 attribute :upstream, :kind_of => [Hash, NilClass], :default => {} # Key value pair of upstream configuration to include outside Server body.
-attribute :reload, :equal_to => [:delayed, :immediately], :default => :delayed # How soon should we restart nginx.
+attribute :reload, :equal_to => [:delayed, :immediately, 'delayed', 'immediately'], :default => :delayed # How soon should we restart nginx.
 attribute :root, :kind_of => [String, NilClass], :default => nil # Server root
 attribute :server_name, :kind_of => [String, Array, NilClass], :default => nil # Server name if different then the name attribute.
 attribute :conf_name, :kind_of => [String, NilClass], :default => nil # Configuration name.
@@ -18,7 +18,7 @@ attribute :template, :kind_of => [String, NilClass], :default => nil # Template 
 attribute :auto_enable_site, :kind_of => [TrueClass, FalseClass] , :default => true # Define if you want to link your newly created site conf from sites-availables to sites-enabled
 attribute :ssl, :kind_of => [Hash, NilClass], :default => nil #Allow the creation of ssl cert files.
 attribute :precedence, :default => :default # Level of attribute precedence to use
-attribute :site_type, :equal_to => [:dynamic, :static], :default => :dynamic 
+attribute :site_type, :equal_to => [:dynamic, :static, 'dynamic', 'static'], :default => :dynamic
 
 def initialize(*args)
   super

--- a/templates/default/conf.erb
+++ b/templates/default/conf.erb
@@ -3,7 +3,7 @@
 <% if !@upstream.empty? %><%= nginx_conf_options(@upstream,0,'upstream') %><% end %>
 server {<% Array(@listen).each do |listen| %>
   listen <%= listen %>;<% end %>
-  server_name <%= Array(@server_name).join(', ') %>;
+  server_name <%= Array(@server_name).join(' ') %>;
   <% if @ssl %>ssl on;
   ssl_certificate <%= @ssl[:certificate] %>;
   ssl_certificate_key <%= @ssl[:certificate_key] %>;<% end %>


### PR DESCRIPTION
When using chef-zero with roles converted to json there is no way to use symbols there.